### PR TITLE
feat: Add MCP StreamableHTTPServerTransport support

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,5 +1,6 @@
 {
   "editor.defaultFormatter": "esbenp.prettier-vscode",
   "editor.formatOnSave": true,
-  "oxc.lint.run": "onSave"
+  "oxc.lint.run": "onSave",
+  "typescript.preferences.importModuleSpecifier": "non-relative"
 }

--- a/bun.lock
+++ b/bun.lock
@@ -6,9 +6,11 @@
       "dependencies": {
         "@anthropic-ai/claude-agent-sdk": "^0.1.1",
         "@modelcontextprotocol/sdk": "^1.18.2",
+        "cors": "^2.8.5",
         "cosmiconfig": "^9.0.0",
         "cosmiconfig-typescript-loader": "^6.1.0",
         "easy-peasy": "^6.1.0",
+        "express": "^5.1.0",
         "ink": "^6.3.1",
         "ink-spinner": "^5.0.0",
         "ink-text-input": "^6.0.0",
@@ -17,6 +19,8 @@
       },
       "devDependencies": {
         "@types/bun": "latest",
+        "@types/cors": "^2.8.19",
+        "@types/express": "^5.0.3",
         "@types/react": "^19.1.16",
         "husky": "^9.1.7",
         "lint-staged": "^16.2.3",
@@ -62,11 +66,33 @@
 
     "@modelcontextprotocol/sdk": ["@modelcontextprotocol/sdk@1.18.2", "", { "dependencies": { "ajv": "^6.12.6", "content-type": "^1.0.5", "cors": "^2.8.5", "cross-spawn": "^7.0.5", "eventsource": "^3.0.2", "eventsource-parser": "^3.0.0", "express": "^5.0.1", "express-rate-limit": "^7.5.0", "pkce-challenge": "^5.0.0", "raw-body": "^3.0.0", "zod": "^3.23.8", "zod-to-json-schema": "^3.24.1" } }, "sha512-beedclIvFcCnPrYgHsylqiYJVJ/CI47Vyc4tY8no1/Li/O8U4BTlJfy6ZwxkYwx+Mx10nrgwSVrA7VBbhh4slg=="],
 
+    "@types/body-parser": ["@types/body-parser@1.19.6", "", { "dependencies": { "@types/connect": "*", "@types/node": "*" } }, "sha512-HLFeCYgz89uk22N5Qg3dvGvsv46B8GLvKKo1zKG4NybA8U2DiEO3w9lqGg29t/tfLRJpJ6iQxnVw4OnB7MoM9g=="],
+
     "@types/bun": ["@types/bun@1.2.23", "", { "dependencies": { "bun-types": "1.2.23" } }, "sha512-le8ueOY5b6VKYf19xT3McVbXqLqmxzPXHsQT/q9JHgikJ2X22wyTW3g3ohz2ZMnp7dod6aduIiq8A14Xyimm0A=="],
+
+    "@types/connect": ["@types/connect@3.4.38", "", { "dependencies": { "@types/node": "*" } }, "sha512-K6uROf1LD88uDQqJCktA4yzL1YYAK6NgfsI0v/mTgyPKWsX1CnJ0XPSDhViejru1GcRkLWb8RlzFYJRqGUbaug=="],
+
+    "@types/cors": ["@types/cors@2.8.19", "", { "dependencies": { "@types/node": "*" } }, "sha512-mFNylyeyqN93lfe/9CSxOGREz8cpzAhH+E93xJ4xWQf62V8sQ/24reV2nyzUWM6H6Xji+GGHpkbLe7pVoUEskg=="],
+
+    "@types/express": ["@types/express@5.0.3", "", { "dependencies": { "@types/body-parser": "*", "@types/express-serve-static-core": "^5.0.0", "@types/serve-static": "*" } }, "sha512-wGA0NX93b19/dZC1J18tKWVIYWyyF2ZjT9vin/NRu0qzzvfVzWjs04iq2rQ3H65vCTQYlRqs3YHfY7zjdV+9Kw=="],
+
+    "@types/express-serve-static-core": ["@types/express-serve-static-core@5.0.7", "", { "dependencies": { "@types/node": "*", "@types/qs": "*", "@types/range-parser": "*", "@types/send": "*" } }, "sha512-R+33OsgWw7rOhD1emjU7dzCDHucJrgJXMA5PYCzJxVil0dsyx5iBEPHqpPfiKNJQb7lZ1vxwoLR4Z87bBUpeGQ=="],
+
+    "@types/http-errors": ["@types/http-errors@2.0.5", "", {}, "sha512-r8Tayk8HJnX0FztbZN7oVqGccWgw98T/0neJphO91KkmOzug1KkofZURD4UaD5uH8AqcFLfdPErnBod0u71/qg=="],
+
+    "@types/mime": ["@types/mime@1.3.5", "", {}, "sha512-/pyBZWSLD2n0dcHE3hq8s8ZvcETHtEuF+3E7XVt0Ig2nvsVQXdghHVcEkIWjy9A0wKfTn97a/PSDYohKIlnP/w=="],
 
     "@types/node": ["@types/node@24.6.0", "", { "dependencies": { "undici-types": "~7.13.0" } }, "sha512-F1CBxgqwOMc4GKJ7eY22hWhBVQuMYTtqI8L0FcszYcpYX0fzfDGpez22Xau8Mgm7O9fI+zA/TYIdq3tGWfweBA=="],
 
+    "@types/qs": ["@types/qs@6.14.0", "", {}, "sha512-eOunJqu0K1923aExK6y8p6fsihYEn/BYuQ4g0CxAAgFc4b/ZLN4CrsRZ55srTdqoiLzU2B2evC+apEIxprEzkQ=="],
+
+    "@types/range-parser": ["@types/range-parser@1.2.7", "", {}, "sha512-hKormJbkJqzQGhziax5PItDUTMAM9uE2XXQmM37dyd4hVM+5aVl7oVxMVUiVQn2oCQFN/LKCZdvSM0pFRqbSmQ=="],
+
     "@types/react": ["@types/react@19.1.16", "", { "dependencies": { "csstype": "^3.0.2" } }, "sha512-WBM/nDbEZmDUORKnh5i1bTnAz6vTohUf9b8esSMu+b24+srbaxa04UbJgWx78CVfNXA20sNu0odEIluZDFdCog=="],
+
+    "@types/send": ["@types/send@0.17.5", "", { "dependencies": { "@types/mime": "^1", "@types/node": "*" } }, "sha512-z6F2D3cOStZvuk2SaP6YrwkNO65iTZcwA2ZkSABegdkAh/lf+Aa/YQndZVfmEXT5vgAp6zv06VQ3ejSVjAny4w=="],
+
+    "@types/serve-static": ["@types/serve-static@1.15.8", "", { "dependencies": { "@types/http-errors": "*", "@types/node": "*", "@types/send": "*" } }, "sha512-roei0UY3LhpOJvjbIP6ZZFngyLKl5dskOtDhxY5THRSpO+ZI+nzJ+m5yUMzGrp89YRa7lvknKkMYjqQFGwA7Sg=="],
 
     "accepts": ["accepts@2.0.0", "", { "dependencies": { "mime-types": "^3.0.0", "negotiator": "^1.0.0" } }, "sha512-5cvg6CtKwfgdmVqY1WIiXKc3Q1bkRqGLi+2W/6ao+6Y7gu/RCwRuAhGEzh5B4KlszSuTLgZYuqFqo5bImjNKng=="],
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -77,7 +77,7 @@
 
 Configurable streaming responses via `config.stream`.
 
-#### MCP Server Integration (As Client)
+### MCP Server Integration (As Client)
 
 The CLI can connect to external MCP servers as a client:
 
@@ -87,33 +87,72 @@ The CLI can connect to external MCP servers as a client:
 - Tool use from any connected server
 - Configured via `mcpServers` in config file
 
+#### MCP Client Flow
+
+1. MCP client calls `query_agent` tool with prompt
+2. Zod validates input schema
+3. `runQuery()` creates a message queue
+4. `createAgentQuery()` initializes agent with shared logic
+5. Prompt is resolved into the message queue
+6. Agent processes via async generator
+7. Response messages are collected
+8. Session state persists for follow-up queries
+9. Final text response returned to MCP client
+
 #### MCP Server Mode
 
-The CLI can also run as an MCP server itself (`bun run server`):
+The CLI can also run as an MCP server itself, exposing the agent as a tool to other MCP clients.
 
-- [src/mcpServer.ts](../src/mcpServer.ts) - MCP server implementation
-- Uses `McpServer` from `@modelcontextprotocol/sdk`
-- Connects via `StdioServerTransport`
-- Exposes a `query_agent` tool with Zod validation
-- Shares the same agent logic as the CLI app
-- Maintains session state across queries
-- Uses the same configuration as CLI mode
-- Tool input: `{ prompt: string }`
-- Tool output: Agent's text response
+**Shared MCP Infrastructure:**
 
-#### Tool Use Tracking
+- [src/mcp/utils/getServer.ts](../src/mcp/utils/getServer.ts) - MCP server factory
+  - Creates `McpServer` instance
+  - Registers `query_agent` tool with Zod validation
+  - Shared by both stdio and HTTP modes
+- [src/mcp/utils/runQuery.ts](../src/mcp/utils/runQuery.ts) - Query execution
+  - Uses shared `createAgentQuery()` from agent integration
+  - Manages message queue and session state
+  - Processes streaming responses
+  - Returns final text response
+
+**Transport Implementations:**
+
+- [src/mcp/stdio.ts](../src/mcp/stdio.ts) - Stdio transport (`bun run server`)
+  - Uses `StdioServerTransport`
+  - For command-line MCP clients
+  - Communicates via stdin/stdout
+
+- [src/mcp/http.ts](../src/mcp/http.ts) - HTTP transport (`bun run server:http`)
+  - Uses `StreamableHTTPServerTransport`
+  - For web/network-based MCP clients
+  - Express server with CORS support
+  - **Session Management:**
+    - Stores transports by session ID in memory
+    - Reuses existing transports for same session
+    - Creates new transport only for `isInitializeRequest`
+  - **HTTP Routes:**
+    - `POST /mcp` - Initialization and JSON-RPC requests
+    - `GET /mcp` - SSE streams for long-lived connections (supports Last-Event-ID for resumability)
+    - `DELETE /mcp` - Session termination
+  - **Lifecycle:**
+    - Connects server to transport before handling first request
+    - Cleans up transports on close
+    - Graceful shutdown via SIGINT handler
+  - Runs on port 3000 by default
+
+### Tool Use Tracking
 
 - Visual display of tool invocations
 - Input parameter formatting
 - Server name extraction from tool names (format: `mcp__servername__toolname`)
 
-#### Session Management
+### Session Management
 
 - Persistent session IDs
 - Message queue for user input
 - Async generator pattern for continuous conversation
 
-#### Cost & Performance Tracking
+### Cost & Performance Tracking
 
 - Duration tracking
 - Cost calculation (USD)
@@ -134,16 +173,6 @@ The CLI can also run as an MCP server itself (`bun run server`):
 8. UI updates reactively via easy-peasy store
 
 #### MCP Server Mode
-
-1. MCP client calls `query_agent` tool with prompt
-2. Zod validates input schema
-3. `runQuery()` creates a message queue
-4. `createAgentQuery()` initializes agent with shared logic
-5. Prompt is resolved into the message queue
-6. Agent processes via async generator
-7. Response messages are collected
-8. Session state persists for follow-up queries
-9. Final text response returned to MCP client
 
 ### Configuration System
 

--- a/package.json
+++ b/package.json
@@ -5,12 +5,15 @@
   "private": true,
   "scripts": {
     "start": "bun run src/index.tsx",
-    "server": "bun run src/mcpServer.ts",
+    "server": "bun run src/mcp/stdio.ts",
+    "server:http": "bun run src/mcp/http.ts",
     "type-check": "tsc --noEmit",
     "prepare": "husky"
   },
   "devDependencies": {
     "@types/bun": "latest",
+    "@types/cors": "^2.8.19",
+    "@types/express": "^5.0.3",
     "@types/react": "^19.1.16",
     "husky": "^9.1.7",
     "lint-staged": "^16.2.3",
@@ -22,9 +25,11 @@
   "dependencies": {
     "@anthropic-ai/claude-agent-sdk": "^0.1.1",
     "@modelcontextprotocol/sdk": "^1.18.2",
+    "cors": "^2.8.5",
     "cosmiconfig": "^9.0.0",
     "cosmiconfig-typescript-loader": "^6.1.0",
     "easy-peasy": "^6.1.0",
+    "express": "^5.1.0",
     "ink": "^6.3.1",
     "ink-spinner": "^5.0.0",
     "ink-text-input": "^6.0.0",

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,6 +1,6 @@
-import { AgentStore } from "./store"
-import { AgentChat } from "./components/AgentChat"
-import { useConfig } from "./hooks/useConfig"
+import { AgentStore } from "store"
+import { AgentChat } from "components/AgentChat"
+import { useConfig } from "hooks/useConfig"
 
 export const App = () => {
   useConfig()

--- a/src/components/AgentChat.tsx
+++ b/src/components/AgentChat.tsx
@@ -1,14 +1,14 @@
 import { Box, Text } from "ink"
 import Spinner from "ink-spinner"
 import TextInput from "ink-text-input"
-import { ChatHeader } from "./ChatHeader"
-import { Markdown } from "./Markdown"
-import { Stats } from "./Stats"
-import { useAgent } from "../hooks/useAgent"
-import { AgentStore } from "../store"
-import { formatToolInput } from "../utils/formatToolInput"
-import { getToolInfo } from "../utils/getToolInfo"
-import { BlinkCaret } from "./BlinkCaret"
+import { ChatHeader } from "components/ChatHeader"
+import { Markdown } from "components/Markdown"
+import { Stats } from "components/Stats"
+import { useAgent } from "hooks/useAgent"
+import { AgentStore } from "store"
+import { formatToolInput } from "utils/formatToolInput"
+import { getToolInfo } from "utils/getToolInfo"
+import { BlinkCaret } from "components/BlinkCaret"
 
 export const AgentChat: React.FC = () => {
   const store = AgentStore.useStoreState((state) => state)
@@ -142,7 +142,7 @@ export const AgentChat: React.FC = () => {
         </Text>
       ) : (
         <Box>
-          <BlinkCaret />
+          <BlinkCaret enabled={store.mcpServers.length > 0} />
 
           <TextInput
             value={store.input}

--- a/src/components/BlinkCaret.tsx
+++ b/src/components/BlinkCaret.tsx
@@ -5,22 +5,26 @@ const BLINK_INTERVAL = 500
 
 interface BlinkCaretProps {
   color?: string
+  enabled?: boolean
   interval?: number
 }
 
 export const BlinkCaret: React.FC<BlinkCaretProps> = ({
   color = "green",
+  enabled = false,
   interval = BLINK_INTERVAL,
 }) => {
-  const [visible, setVisible] = useState(true)
+  const [visible, setVisible] = useState(false)
 
   useEffect(() => {
+    if (!enabled) return
+
     const refreshInterval = setInterval(() => {
       setVisible((v) => !v)
     }, interval)
 
     return () => clearInterval(refreshInterval)
-  }, [])
+  }, [enabled])
 
   return (
     <Text color={color} dimColor={!visible}>

--- a/src/components/ChatHeader.tsx
+++ b/src/components/ChatHeader.tsx
@@ -1,6 +1,6 @@
 import { Box, Text } from "ink"
 import Spinner from "ink-spinner"
-import { AgentStore } from "../store"
+import { AgentStore } from "store"
 
 export const ChatHeader: React.FC = () => {
   const store = AgentStore.useStoreState((state) => state)

--- a/src/components/Stats.tsx
+++ b/src/components/Stats.tsx
@@ -1,5 +1,5 @@
 import { Box, Text } from "ink"
-import { AgentStore } from "../store"
+import { AgentStore } from "store"
 
 export const Stats: React.FC = () => {
   const stats = AgentStore.useStoreState((state) => state.stats)

--- a/src/components/ToolUses.tsx
+++ b/src/components/ToolUses.tsx
@@ -1,23 +1,11 @@
 import { Box, Text } from "ink"
-import { AgentStore } from "../store"
-import { formatToolInput } from "../utils/formatToolInput"
-
-const renderToolInput = (obj: Record<string, unknown>) => {
-  // Format the input (detects GraphQL queries and formats appropriately)
-  const formattedString = formatToolInput(obj)
-
-  // Split on actual newline characters and render each line
-  return (
-    <>
-      {formattedString.split('\n').map((line, idx) => (
-        <Text key={idx} dimColor>{line}</Text>
-      ))}
-    </>
-  )
-}
+import { AgentStore } from "store"
+import { formatToolInput } from "utils/formatToolInput"
 
 export const ToolUses: React.FC = () => {
-  const currentToolUses = AgentStore.useStoreState((state) => state.currentToolUses)
+  const currentToolUses = AgentStore.useStoreState(
+    (state) => state.currentToolUses
+  )
 
   if (currentToolUses.length === 0) {
     return null
@@ -30,17 +18,20 @@ export const ToolUses: React.FC = () => {
 
         if (parts.length >= 3 && parts[0] === "mcp") {
           const serverName = parts[1]
-          const actualToolName = parts.slice(2).join("__")
+          const toolName = parts.slice(2).join("__")
 
           return (
             <Box key={idx} flexDirection="column" marginBottom={1}>
               <Box>
                 <Text color="yellow">[server] </Text>
+
                 <Text bold color="yellow">
                   {serverName}
                 </Text>
-                <Text color="yellow">: {actualToolName}</Text>
+
+                <Text color="yellow">: {toolName}</Text>
               </Box>
+
               <Box marginLeft={2} flexDirection="column">
                 {renderToolInput(tool.input)}
               </Box>
@@ -51,6 +42,7 @@ export const ToolUses: React.FC = () => {
         return (
           <Box key={idx} flexDirection="column" marginBottom={1}>
             <Text color="yellow">[tool] {tool.name}</Text>
+
             <Box marginLeft={2} flexDirection="column">
               {renderToolInput(tool.input)}
             </Box>
@@ -58,5 +50,19 @@ export const ToolUses: React.FC = () => {
         )
       })}
     </Box>
+  )
+}
+
+const renderToolInput = (obj: Record<string, unknown>) => {
+  const toolInput = formatToolInput(obj)
+
+  return (
+    <>
+      {toolInput.split("\n").map((line, idx) => (
+        <Text key={idx} dimColor>
+          {line}
+        </Text>
+      ))}
+    </>
   )
 }

--- a/src/hooks/useAgent.ts
+++ b/src/hooks/useAgent.ts
@@ -1,7 +1,7 @@
 import { useEffect, useRef } from "react"
-import { AgentStore } from "../store"
-import { useMcpServers } from "./useMcpServers"
-import { createAgentQuery, messageTypes } from "../utils/runAgent"
+import { AgentStore } from "store"
+import { useMcpServers } from "hooks/useMcpServers"
+import { createAgentQuery, messageTypes } from "utils/runAgent"
 
 export function useAgent() {
   const messageQueue = AgentStore.useStoreState((state) => state.messageQueue)

--- a/src/hooks/useConfig.ts
+++ b/src/hooks/useConfig.ts
@@ -1,6 +1,6 @@
 import { useEffect } from "react"
-import { AgentStore } from "../store"
-import { loadConfig } from "../utils/loadConfig"
+import { AgentStore } from "store"
+import { loadConfig } from "utils/loadConfig"
 
 export const useConfig = () => {
   const config = AgentStore.useStoreState((state) => state.config)

--- a/src/hooks/useMcpServers.ts
+++ b/src/hooks/useMcpServers.ts
@@ -1,4 +1,4 @@
-import { AgentStore } from "../store"
+import { AgentStore } from "store"
 
 const CONNECTION_TIMEOUT = 10000
 const MAX_RETRIES = 3

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -1,7 +1,7 @@
 import { render } from "ink"
 import { App } from "./App"
-import { validateEnv } from "./utils/validateEnv"
-import { AgentStore } from "./store"
+import { validateEnv } from "utils/validateEnv"
+import { AgentStore } from "store"
 
 const main = () => {
   validateEnv()

--- a/src/mcp/http.ts
+++ b/src/mcp/http.ts
@@ -1,0 +1,185 @@
+import { StreamableHTTPServerTransport } from "@modelcontextprotocol/sdk/server/streamableHttp.js"
+import { isInitializeRequest } from "@modelcontextprotocol/sdk/types.js"
+import { randomUUID } from "node:crypto"
+import { loadConfig } from "utils/loadConfig"
+import { getMcpServer } from "mcp/utils/getMcpServer"
+import express from "express"
+import cors from "cors"
+
+const PORT = 3000
+
+export const main = async () => {
+  await loadConfig()
+
+  const app = express()
+
+  const transports: Record<string, StreamableHTTPServerTransport> = {}
+
+  app.use(express.json())
+
+  app.use(
+    cors({
+      origin: "*",
+      exposedHeaders: ["Mcp-Session-Id"],
+    })
+  )
+
+  app.post("/mcp", async (req, res) => {
+    const sessionId = req.headers["mcp-session-id"] as string | undefined
+
+    if (sessionId) {
+      console.log(
+        `[agent-chat-cli] Received MCP request for session: ${sessionId}`
+      )
+    } else {
+      console.log("[agent-chat-cli] New MCP request")
+    }
+
+    try {
+      let transport: StreamableHTTPServerTransport
+
+      if (sessionId && transports[sessionId]) {
+        transport = transports[sessionId]
+      } else if (!sessionId && isInitializeRequest(req.body)) {
+        transport = new StreamableHTTPServerTransport({
+          sessionIdGenerator: () => randomUUID(),
+          onsessioninitialized: (newSessionId) => {
+            console.log(
+              `[agent-chat-cli] Session initialized with ID: ${newSessionId}`
+            )
+
+            transports[newSessionId] = transport
+          },
+        })
+
+        transport.onclose = () => {
+          const sid = transport.sessionId
+
+          if (sid && transports[sid]) {
+            console.log(`[agent-chat-cli] Transport closed for session ${sid}`)
+            delete transports[sid]
+          }
+        }
+
+        const server = getMcpServer()
+
+        await server.connect(transport)
+        await transport.handleRequest(req, res, req.body)
+
+        return
+      } else {
+        res.status(400).json({
+          jsonrpc: "2.0",
+          error: {
+            code: -32000,
+            message: "Bad Request: No valid session ID provided",
+          },
+          id: null,
+        })
+        return
+      }
+
+      await transport.handleRequest(req, res, req.body)
+    } catch (error) {
+      console.error("[agent-chat-cli] Error handling MCP request:", error)
+
+      if (!res.headersSent) {
+        res.status(500).json({
+          jsonrpc: "2.0",
+          error: {
+            code: -32603,
+            message: "Internal server error",
+          },
+          id: null,
+        })
+      }
+    }
+  })
+
+  app.get("/mcp", async (req, res) => {
+    const sessionId = req.headers["mcp-session-id"] as string | undefined
+
+    if (!sessionId || !transports[sessionId]) {
+      res.status(400).send("Invalid or missing session ID")
+      return
+    }
+
+    const lastEventId = req.headers["last-event-id"]
+
+    if (lastEventId) {
+      console.log(
+        `[agent-chat-cli] Client reconnecting with Last-Event-ID: ${lastEventId}`
+      )
+    } else {
+      console.log(
+        `[agent-chat-cli] Establishing new HTTP stream for session ${sessionId}`
+      )
+    }
+
+    const transport = transports[sessionId]
+    await transport.handleRequest(req, res)
+  })
+
+  app.delete("/mcp", async (req, res) => {
+    const sessionId = req.headers["mcp-session-id"] as string | undefined
+
+    if (!sessionId || !transports[sessionId]) {
+      res.status(400).send("Invalid or missing session ID")
+      return
+    }
+
+    console.log(
+      `[agent-chat-cli] Received session termination request for session ${sessionId}`
+    )
+
+    try {
+      const transport = transports[sessionId]
+      await transport.handleRequest(req, res)
+    } catch (error) {
+      console.error(
+        "[agent-chat-cli] Error handling session termination:",
+        error
+      )
+
+      if (!res.headersSent) {
+        res.status(500).send("Error processing session termination")
+      }
+    }
+  })
+
+  app.listen(PORT, () => {
+    console.log(
+      `\n[agent-chat-cli] MCP HTTP Server running on port http://localhost:${PORT}\n`
+    )
+  })
+
+  process.on("SIGINT", async () => {
+    console.log("[agent-chat-cli] Shutting down server...")
+
+    for (const sessionId in transports) {
+      try {
+        console.log(
+          `[agent-chat-cli] Closing transport for session ${sessionId}`
+        )
+
+        await transports[sessionId]?.close()
+        delete transports[sessionId]
+      } catch (error) {
+        console.error(
+          `[agent-chat-cli] Error closing transport for session ${sessionId}:`,
+          error
+        )
+      }
+    }
+
+    console.log("[agent-chat-cli] Server shutdown complete")
+    process.exit(0)
+  })
+}
+
+try {
+  main()
+} catch (error) {
+  console.error("[agent-chat-cli] Fatal error starting HTTP server:", error)
+  process.exit(1)
+}

--- a/src/mcp/stdio.ts
+++ b/src/mcp/stdio.ts
@@ -1,0 +1,20 @@
+import { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio.js"
+import { loadConfig } from "utils/loadConfig"
+import { getMcpServer } from "mcp/utils/getMcpServer"
+
+export const main = async () => {
+  try {
+    await loadConfig()
+    const mcpServer = getMcpServer()
+
+    const transport = new StdioServerTransport()
+    await mcpServer.connect(transport)
+
+    console.error("\n[agent-chat-cli] MCP Server running on stdio\n")
+  } catch (error) {
+    console.error("[agent-chat-cli] Fatal error running server:", error)
+    process.exit(1)
+  }
+}
+
+main()

--- a/src/mcp/utils/getMcpServer.ts
+++ b/src/mcp/utils/getMcpServer.ts
@@ -1,0 +1,35 @@
+import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js"
+import { runQuery } from "mcp/utils/runQuery"
+import { z } from "zod"
+
+export const getMcpServer = () => {
+  const mcpServer = new McpServer({
+    name: "agent-chat-cli",
+    version: "0.1.0",
+  })
+
+  mcpServer.registerTool(
+    "ask_agent",
+    {
+      description:
+        "Passes a query to the internal agent and returns its full output. The agent has access to configured MCP tools and will provide a complete response. DO NOT reprocess, analyze, or summarize the output - return it directly to the user as-is.",
+      inputSchema: {
+        query: z.string().min(1).describe("The query to send to the agent"),
+      },
+    },
+    async ({ query }) => {
+      const result = await runQuery(query)
+
+      return {
+        content: [
+          {
+            type: "text",
+            text: result,
+          },
+        ],
+      }
+    }
+  )
+
+  return mcpServer
+}

--- a/src/utils/runAgent.ts
+++ b/src/utils/runAgent.ts
@@ -1,6 +1,6 @@
 import { query, type SDKUserMessage } from "@anthropic-ai/claude-agent-sdk"
-import type { AgentChatConfig } from "../store"
-import { buildSystemPrompt } from "../utils/getPrompt"
+import type { AgentChatConfig } from "store"
+import { buildSystemPrompt } from "utils/getPrompt"
 
 export const messageTypes = {
   ASSISTANT: "assistant",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,6 +1,7 @@
 {
   "compilerOptions": {
     // Environment setup & latest features
+    "baseUrl": "./src",
     "lib": ["ESNext"],
     "target": "ESNext",
     "module": "Preserve",


### PR DESCRIPTION
Adds an example using `StreamableHTTPServerTransport`. Still not ideal, as many MCP clients don't support sampling and thus reprocessing occurs, and latency is high. 

Also some light cleanup:
- absolute import paths 
- reorg/modularization of mcp server stuff