### PR TITLE
feat: Add support for running interactive agent as an MCP client

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,12 +2,15 @@
 
 A bare-bones, terminal-based agent app built to explore the new [Claude Agent SDK](https://docs.claude.com/en/api/agent-sdk/overview). Terminal rendering is built on top of [React Ink](https://github.com/vadimdemedes/ink).
 
-The app has two modes:
+The app has three modes:
 
-- An interactive terminal app
-- Stand-alone MCP server. Expose the agent as a tool to other MCP clients.
+- Interactive terminal app which communicates with LLM directly.
+- Interactive terminal app _as a stand-alone MCP client_ with no direct LLM communication, serving as a frontend to the agent or other MCP servers.
+- Stand-alone MCP server which clients can connect to, without TUI.
 
-MCP servers can be configured in [agent-chat-cli.config.ts](agent-chat-cli.config.ts).
+The agent, including MCP server setup, is configured in [agent-chat-cli.config.ts](agent-chat-cli.config.ts).
+
+The MCP _client_ is configured in [mcp-client.config.ts](mcp-client.config.ts).
 
 https://github.com/user-attachments/assets/00cfb9b6-ac65-4b95-8842-28ad0414ffd9
 
@@ -29,7 +32,7 @@ Then edit `.env` and fill in the required values.
 
 ### Usage
 
-#### Interactive Mode
+#### Interactive Agent Mode
 
 Run the agent in interactive terminal mode:
 
@@ -41,12 +44,24 @@ You'll see a prompt where you can type your questions or requests.
 
 Type `exit` to quit.
 
-#### MCP Server Mode
+#### Interactive MCP Client
 
-Run as an MCP server, using one of two modes:
+To run as an MCP client (connecting to an MCP server):
 
 ```bash
-bun run server # stdio
+bun start:client
+```
+
+By default it will launch the MCP stdio server in the background (ie, `bun server`).
+
+Configure the MCP server connection in `mcp-client.config.ts`. HTTP is also supported.
+
+#### MCP Server Mode
+
+Run as a stand-alone MCP server, using one of two modes:
+
+```bash
+bun run server
 bun run server:http
 ```
 

--- a/mcp-client.config.ts
+++ b/mcp-client.config.ts
@@ -1,0 +1,22 @@
+export type McpClientConfig =
+  | {
+      transport: "stdio"
+      command: string
+      args?: string[]
+    }
+  | {
+      transport: "http" | "sse"
+      url: string
+    }
+
+const config: McpClientConfig = {
+  transport: "stdio",
+  command: "bun",
+  args: ["run", "server"],
+
+  // Or connect to your MCP server via HTTP
+  // transport: "http",
+  // url: "http://localhost:3000/mcp",
+}
+
+export default config

--- a/package.json
+++ b/package.json
@@ -5,6 +5,7 @@
   "private": true,
   "scripts": {
     "start": "bun run src/index.tsx",
+    "start:client": "bun run src/index.tsx --client",
     "server": "bun run src/mcp/stdio.ts",
     "server:http": "bun run src/mcp/http.ts",
     "type-check": "tsc --noEmit",

--- a/src/components/AgentChat.tsx
+++ b/src/components/AgentChat.tsx
@@ -5,6 +5,7 @@ import { ChatHeader } from "components/ChatHeader"
 import { Markdown } from "components/Markdown"
 import { Stats } from "components/Stats"
 import { useAgent } from "hooks/useAgent"
+import { useMcpClient } from "hooks/useMcpClient"
 import { AgentStore } from "store"
 import { formatToolInput } from "utils/formatToolInput"
 import { getToolInfo } from "utils/getToolInfo"
@@ -14,11 +15,16 @@ export const AgentChat: React.FC = () => {
   const store = AgentStore.useStoreState((state) => state)
   const actions = AgentStore.useStoreActions((actions) => actions)
 
-  useAgent()
+  const isClient = process.argv.includes("--client")
+
+  if (isClient) {
+    useMcpClient()
+  } else {
+    useAgent()
+  }
 
   const handleSubmit = (value: string) => {
     if (value.toLowerCase() === "exit") {
-      actions.setShouldExit(true)
       process.exit(0)
     }
 
@@ -34,6 +40,7 @@ export const AgentChat: React.FC = () => {
 
     if (store.messageQueue.length > 0) {
       const item = store.messageQueue.shift()
+
       if (item) {
         item.resolve(value)
       }
@@ -42,16 +49,8 @@ export const AgentChat: React.FC = () => {
     actions.setInput("")
   }
 
-  if (store.shouldExit) {
-    return (
-      <Box flexDirection="column">
-        <Text>👋 Goodbye!</Text>
-      </Box>
-    )
-  }
-
   return (
-    <Box flexDirection="column">
+    <Box flexDirection="column" paddingLeft={1}>
       <ChatHeader />
 
       <Box flexDirection="column">

--- a/src/hooks/useMcpClient.ts
+++ b/src/hooks/useMcpClient.ts
@@ -1,0 +1,161 @@
+import { useEffect, useRef } from "react"
+import { Client } from "@modelcontextprotocol/sdk/client/index.js"
+import { StdioClientTransport } from "@modelcontextprotocol/sdk/client/stdio.js"
+import { StreamableHTTPClientTransport } from "@modelcontextprotocol/sdk/client/streamableHttp.js"
+import {
+  LoggingMessageNotificationSchema,
+  type LoggingMessageNotification,
+} from "@modelcontextprotocol/sdk/types.js"
+import { AgentStore } from "store"
+import config from "../../mcp-client.config"
+
+export const useMcpClient = () => {
+  const messageQueue = AgentStore.useStoreState((state) => state.messageQueue)
+  const actions = AgentStore.useStoreActions((actions) => actions)
+
+  useEffect(() => {
+    const runClient = async () => {
+      try {
+        const client = new Client(
+          {
+            name: "agent-chat-cli-client",
+            version: "1.0.0",
+          },
+          {
+            capabilities: {
+              elicitation: {},
+            },
+          }
+        )
+
+        client.setNotificationHandler(
+          LoggingMessageNotificationSchema,
+          (notification: LoggingMessageNotification) => {
+            if (notification.params?.data) {
+              try {
+                const dataStr =
+                  typeof notification.params.data === "string"
+                    ? notification.params.data
+                    : JSON.stringify(notification.params.data)
+
+                const data = JSON.parse(dataStr)
+
+                if (data.type === "tool_use") {
+                  actions.addChatHistoryEntry({
+                    type: "tool_use",
+                    name: data.name,
+                    input: data.input as Record<string, unknown>,
+                  })
+
+                  actions.addToolUse({
+                    type: "tool_use",
+                    name: data.name,
+                    input: data.input as Record<string, unknown>,
+                  })
+                } else if (data.type === "mcp_servers") {
+                  actions.setMcpServers(data.servers)
+                }
+              } catch {
+                // noop
+              }
+            }
+          }
+        )
+
+        let transport: StdioClientTransport | StreamableHTTPClientTransport =
+          (() => {
+            switch (true) {
+              case config.transport === "stdio": {
+                return new StdioClientTransport({
+                  command: config.command,
+                  args: config.args || [],
+                })
+              }
+
+              case config.transport === "http" || config.transport === "sse": {
+                return new StreamableHTTPClientTransport(new URL(config.url))
+              }
+
+              default: {
+                throw new Error(
+                  `[agent-chat-cli] Unsupported transport: ${config.transport}`
+                )
+              }
+            }
+          })()
+
+        actions.setSessionId("mcp-client-session")
+
+        await client.connect(transport)
+        await client.setLoggingLevel("debug")
+
+        // Check to see what tools are available and update status
+        await client.callTool({
+          name: "get_agent_status",
+          arguments: {},
+        })
+
+        // Wait for messages from the queue
+        while (true) {
+          const userMessage = await new Promise<string>((resolve) => {
+            messageQueue.push({ resolve })
+          })
+
+          if (userMessage.toLowerCase() === "exit") {
+            break
+          }
+
+          if (!userMessage.trim()) {
+            continue
+          }
+
+          try {
+            const startTime = Date.now()
+
+            const result = await client.callTool({
+              name: "ask_agent",
+              arguments: {
+                query: userMessage,
+              },
+            })
+
+            const duration = Date.now() - startTime
+
+            let responseText = ""
+
+            if (result.content && Array.isArray(result.content)) {
+              for (const item of result.content) {
+                if (item.type === "text") {
+                  responseText += item.text
+                }
+              }
+            }
+
+            if (responseText) {
+              actions.addChatHistoryEntry({
+                type: "message",
+                role: "assistant",
+                content: responseText,
+              })
+            }
+
+            actions.setStats(`Completed in ${(duration / 1000).toFixed(2)}s`)
+            actions.setIsProcessing(false)
+          } catch (error) {
+            actions.setStats(
+              `[agent-chat-cli] Error: ${error instanceof Error ? error.message : String(error)}`
+            )
+            actions.setIsProcessing(false)
+          }
+        }
+      } catch (error) {
+        actions.setStats(
+          `[agent-chat-cli] Client error: ${error instanceof Error ? error.message : String(error)}`
+        )
+        actions.setIsProcessing(false)
+      }
+    }
+
+    runClient()
+  }, [])
+}

--- a/src/mcp/utils/getAgentStatus.ts
+++ b/src/mcp/utils/getAgentStatus.ts
@@ -1,0 +1,45 @@
+import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js"
+import { loadConfig } from "utils/loadConfig"
+import { createAgentQuery, messageTypes } from "utils/runAgent"
+
+export const getAgentStatus = async (mcpServer?: McpServer) => {
+  const config = await loadConfig()
+  const messageQueue: { resolve: (value: string) => void }[] = []
+
+  const { response } = createAgentQuery({
+    messageQueue,
+    config,
+  })
+
+  await new Promise((resolve) => setTimeout(resolve, 0))
+
+  messageQueue[0]?.resolve("status")
+
+  for await (const message of response) {
+    if (
+      message.type === messageTypes.SYSTEM &&
+      message.subtype === messageTypes.INIT
+    ) {
+      // Emit MCP servers notification
+      if (mcpServer && message.mcp_servers) {
+        await mcpServer.sendLoggingMessage({
+          level: "info",
+          data: JSON.stringify({
+            type: "mcp_servers",
+            servers: message.mcp_servers,
+          }),
+        })
+      }
+
+      return {
+        sessionId: message.session_id,
+        mcpServers: message.mcp_servers,
+      }
+    }
+  }
+
+  return {
+    sessionId: undefined,
+    mcpServers: [],
+  }
+}

--- a/src/mcp/utils/getMcpServer.ts
+++ b/src/mcp/utils/getMcpServer.ts
@@ -1,12 +1,20 @@
 import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js"
 import { runQuery } from "mcp/utils/runQuery"
+import { getAgentStatus } from "mcp/utils/getAgentStatus"
 import { z } from "zod"
 
 export const getMcpServer = () => {
-  const mcpServer = new McpServer({
-    name: "agent-chat-cli",
-    version: "0.1.0",
-  })
+  const mcpServer = new McpServer(
+    {
+      name: "agent-chat-cli",
+      version: "0.1.0",
+    },
+    {
+      capabilities: {
+        logging: {},
+      },
+    }
+  )
 
   mcpServer.registerTool(
     "ask_agent",
@@ -18,13 +26,37 @@ export const getMcpServer = () => {
       },
     },
     async ({ query }) => {
-      const result = await runQuery(query)
+      const result = await runQuery({
+        prompt: query,
+        mcpServer,
+      })
 
       return {
         content: [
           {
             type: "text",
             text: result,
+          },
+        ],
+      }
+    }
+  )
+
+  mcpServer.registerTool(
+    "get_agent_status",
+    {
+      description:
+        "Get the status of the agent including which MCP servers it has access to. Call this on initialization to see available servers.",
+      inputSchema: {},
+    },
+    async () => {
+      const status = await getAgentStatus(mcpServer)
+
+      return {
+        content: [
+          {
+            type: "text",
+            text: JSON.stringify(status, null, 2),
           },
         ],
       }

--- a/src/store.ts
+++ b/src/store.ts
@@ -48,7 +48,6 @@ export interface StoreModel {
   mcpServers: McpServerStatus[]
   messageQueue: { resolve: (value: string) => void }[]
   sessionId?: string
-  shouldExit: boolean
   stats?: string | null
 
   // Computed
@@ -67,7 +66,6 @@ export interface StoreModel {
   setIsProcessing: Action<StoreModel, boolean>
   setMcpServers: Action<StoreModel, McpServerStatus[]>
   setSessionId: Action<StoreModel, string>
-  setShouldExit: Action<StoreModel, boolean>
   setStats: Action<StoreModel, string | null>
 }
 
@@ -81,7 +79,6 @@ export const AgentStore = createContextStore<StoreModel>({
   currentAssistantMessage: "",
   currentToolUses: [],
   stats: undefined,
-  shouldExit: false,
   config: null as unknown as AgentChatConfig,
 
   // Computed
@@ -128,10 +125,6 @@ export const AgentStore = createContextStore<StoreModel>({
 
   setStats: action((state, payload) => {
     state.stats = payload
-  }),
-
-  setShouldExit: action((state, payload) => {
-    state.shouldExit = payload
   }),
 
   clearCurrentAssistantMessage: action((state) => {


### PR DESCRIPTION
With the agent terminal ui -> llm connection complete, and the MCP server side complete, we need a way to _efficiently_ connect to the MCP server, without reprocessing responses and increasing latency. 

To do this we leverage all of the existing work completed around the agent TUI, but instead of communicating directly with the LLM from within a running application, it makes tool calls out to the MCP server and the MCP server emits events which the MCP client can listen to about what tools are being invoked, etc, effectively becoming a decoupled chat UI.

With this in place we can now create more sophisticated UI around the agent all over MCP protocol, using MCP up and down (while still keeping all of the existing TUI behaviors as seen in the existing agent). 

To run:
- `bun start:client`