### PR TITLE
feat: Add tool use confirmation support

### DIFF
--- a/agent-chat-cli.config.ts
+++ b/agent-chat-cli.config.ts
@@ -4,22 +4,6 @@ import { getPrompt } from "./src/utils/getPrompt"
 const config: AgentChatConfig = {
   stream: false,
   mcpServers: {
-    artsymcp: {
-      prompt: getPrompt("artsy-mcp.md"),
-      command: "npx",
-      args: [
-        "mcp-remote@0.1.29",
-        "https://mcp.stg.artsy.systems/mcp",
-        "--header",
-        `x-access-token:${process.env.ARTSY_MCP_X_ACCESS_TOKEN}`,
-        "--header",
-        `x-user-id:${process.env.ARTSY_MCP_X_USER_ID}`,
-      ],
-      env: {
-        X_ACCESS_TOKEN: process.env.ARTSY_MCP_X_ACCESS_TOKEN!,
-        X_USER_ID: process.env.ARTSY_MCP_X_USER_ID!,
-      },
-    },
     github: {
       prompt: getPrompt("github.md"),
       command: "npx",

--- a/src/components/AgentChat.tsx
+++ b/src/components/AgentChat.tsx
@@ -4,6 +4,7 @@ import TextInput from "ink-text-input"
 import { ChatHeader } from "components/ChatHeader"
 import { Markdown } from "components/Markdown"
 import { Stats } from "components/Stats"
+import { ToolPermissionPrompt } from "components/ToolPermissionPrompt"
 import { useAgent } from "hooks/useAgent"
 import { useMcpClient } from "hooks/useMcpClient"
 import { AgentStore } from "store"
@@ -138,24 +139,38 @@ export const AgentChat: React.FC = () => {
         <Stats />
       </Box>
 
-      {store.isProcessing ? (
-        <Text dimColor>
-          <Text color="cyan">
-            <Spinner type="balloon" />
-          </Text>
-          {" Agent is thinking..."}
-        </Text>
-      ) : (
-        <Box>
-          <BlinkCaret enabled={store.mcpServers.length > 0} />
+      {(() => {
+        switch (true) {
+          case !!store.pendingToolPermission: {
+            return <ToolPermissionPrompt />
+          }
 
-          <TextInput
-            value={store.input}
-            onChange={actions.setInput}
-            onSubmit={handleSubmit}
-          />
-        </Box>
-      )}
+          case store.isProcessing: {
+            return (
+              <Text dimColor>
+                <Text color="cyan">
+                  <Spinner type="balloon" />
+                </Text>
+                {" Agent is thinking..."}
+              </Text>
+            )
+          }
+
+          default: {
+            return (
+              <Box>
+                <BlinkCaret enabled={store.mcpServers.length > 0} />
+
+                <TextInput
+                  value={store.input}
+                  onChange={actions.setInput}
+                  onSubmit={handleSubmit}
+                />
+              </Box>
+            )
+          }
+        }
+      })()}
 
       <Box marginTop={1} />
     </Box>

--- a/src/components/ToolPermissionPrompt.tsx
+++ b/src/components/ToolPermissionPrompt.tsx
@@ -1,0 +1,86 @@
+import { Box, Text, useInput } from "ink"
+import TextInput from "ink-text-input"
+import { AgentStore } from "store"
+import { formatToolInput } from "utils/formatToolInput"
+import { getToolInfo } from "utils/getToolInfo"
+
+export const ToolPermissionPrompt: React.FC = () => {
+  const store = AgentStore.useStoreState((state) => state)
+  const actions = AgentStore.useStoreActions((actions) => actions)
+
+  if (!store.pendingToolPermission) return null
+
+  const { toolName, input } = store.pendingToolPermission
+  const { serverName, toolName: shortToolName } = getToolInfo(toolName)
+
+  const handleSubmit = (value: string) => {
+    if (store.messageQueue.length > 0) {
+      const item = store.messageQueue.shift()
+      if (item) {
+        item.resolve(value)
+      }
+    }
+
+    actions.setPendingToolPermission(undefined)
+    actions.setInput("")
+  }
+
+  useInput((input, key) => {
+    if (key.return) {
+      // Enter = yes/allow
+      handleSubmit("y")
+    } else if (key.escape) {
+      // ESC = no/deny
+      handleSubmit("n")
+    }
+  })
+
+  return (
+    <Box flexDirection="column" marginBottom={1}>
+      <Text bold color="yellow">
+        [Tool Permission Request]
+      </Text>
+
+      <Box marginLeft={2} flexDirection="column">
+        <Box>
+          <Text bold>Tool: </Text>
+          {serverName ? (
+            <>
+              <Text color="cyan">[{serverName}]</Text>
+              <Text> {shortToolName}</Text>
+            </>
+          ) : (
+            <Text>{toolName}</Text>
+          )}
+        </Box>
+
+        <Box flexDirection="column" marginTop={1}>
+          <Text bold>Input:</Text>
+          <Box marginLeft={2} flexDirection="column">
+            {formatToolInput(input)
+              .split("\n")
+              .map((line, idx) => (
+                <Text key={idx} dimColor>
+                  {line}
+                </Text>
+              ))}
+          </Box>
+        </Box>
+
+        <Box marginTop={1}>
+          <Text dimColor>
+            Allow? (Enter=yes, ESC=no, or type modified input):{" "}
+          </Text>
+        </Box>
+
+        <Box>
+          <TextInput
+            value={store.input}
+            onChange={actions.setInput}
+            onSubmit={handleSubmit}
+          />
+        </Box>
+      </Box>
+    </Box>
+  )
+}

--- a/src/hooks/useAgent.ts
+++ b/src/hooks/useAgent.ts
@@ -19,6 +19,9 @@ export function useAgent() {
         messageQueue,
         sessionId,
         config,
+        onToolPermissionRequest: (toolName, input) => {
+          actions.setPendingToolPermission({ toolName, input })
+        },
       })
 
       await initMcpServers(response)

--- a/src/store.ts
+++ b/src/store.ts
@@ -38,6 +38,11 @@ export interface AgentChatConfig {
   mcpServers: Record<string, McpServerConfigWithPrompt>
 }
 
+export interface PendingToolPermission {
+  toolName: string
+  input: any
+}
+
 export interface StoreModel {
   chatHistory: ChatHistoryEntry[]
   config: AgentChatConfig
@@ -47,6 +52,7 @@ export interface StoreModel {
   isProcessing: boolean
   mcpServers: McpServerStatus[]
   messageQueue: { resolve: (value: string) => void }[]
+  pendingToolPermission?: PendingToolPermission
   sessionId?: string
   stats?: string | null
 
@@ -59,6 +65,10 @@ export interface StoreModel {
   appendCurrentAssistantMessage: Action<StoreModel, string>
   clearCurrentAssistantMessage: Action<StoreModel>
   clearToolUses: Action<StoreModel>
+  setPendingToolPermission: Action<
+    StoreModel,
+    PendingToolPermission | undefined
+  >
   setConfig: Action<StoreModel, AgentChatConfig>
   setcurrentAssistantMessage: Action<StoreModel, string>
   setCurrentToolUses: Action<StoreModel, ToolUse[]>
@@ -78,6 +88,7 @@ export const AgentStore = createContextStore<StoreModel>({
   isProcessing: false,
   currentAssistantMessage: "",
   currentToolUses: [],
+  pendingToolPermission: undefined,
   stats: undefined,
   config: null as unknown as AgentChatConfig,
 
@@ -137,5 +148,9 @@ export const AgentStore = createContextStore<StoreModel>({
 
   setConfig: action((state, payload) => {
     state.config = payload
+  }),
+
+  setPendingToolPermission: action((state, payload) => {
+    state.pendingToolPermission = payload
   }),
 })

--- a/src/utils/canUseTool.ts
+++ b/src/utils/canUseTool.ts
@@ -1,0 +1,40 @@
+export interface CanUseToolOptions {
+  messageQueue: { resolve: (value: string) => void }[]
+  onToolPermissionRequest: (toolName: string, input: any) => void
+}
+
+export const createCanUseTool = (options: CanUseToolOptions) => {
+  const { messageQueue, onToolPermissionRequest } = options
+
+  return async (toolName: string, input: any) => {
+    // Notify UI
+    onToolPermissionRequest(toolName, input)
+
+    const userResponse = await new Promise<string>((resolve) => {
+      messageQueue.push({ resolve })
+    })
+
+    const response = userResponse.toLowerCase().trim()
+
+    // Enter pressed (empty) or explicit "y"/"yes"/"allow"
+    if (!response || ["y", "yes", "allow"].includes(response)) {
+      return { behavior: "allow" as const, updatedInput: input }
+    }
+
+    // ESC or explicit "n"/"no"/"deny"
+    if (["n", "no", "deny"].includes(response)) {
+      return {
+        behavior: "deny" as const,
+        message: "User denied permission",
+        interrupt: true,
+      }
+    }
+
+    // Any other input is treated as a deny
+    return {
+      behavior: "deny" as const,
+      message: "User modified input",
+      interrupt: true,
+    }
+  }
+}


### PR DESCRIPTION
Before things were too permissive. We want to support granular tool call permissions. This adds that. 

<img width="423" height="433" alt="Screenshot 2025-10-03 at 1 41 45 PM" src="https://github.com/user-attachments/assets/5a9051c0-e7ca-4e9c-87a6-097dd012ef39" />
