### PR TITLE
feat: Add new `denyTools` config option passed per server config

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -12,10 +12,12 @@ Default to using Bun instead of Node.js.
 ## Main Rules
 
 - **CRITICAL:** For questions about overall architecture, please see `/docs/architecture.md`. Read it.
+- Prefer map/filter/forEach/reduce over imperative forms
 - Prefer `const foo = () => { ... }` over `function foo`
 - Prefer named exports vs default exports
 - Prefer try/catch over vanilla promises
-- Never use implicit returns in react components. They should ONLY be used in one-liners.
+- If a function has two or more arguments, use an object. And use an interface, vs adding types inline.
+- Never use implicit returns in react components. They should ONLY be used in one-liners.-
 
 ## APIs
 

--- a/agent-chat-cli.config.ts
+++ b/agent-chat-cli.config.ts
@@ -17,6 +17,7 @@ const config: AgentChatConfig = {
       env: {
         GITHUB_ACCESS_TOKEN: process.env.GITHUB_ACCESS_TOKEN!,
       },
+      denyTools: ["search_repositories", "search_code"],
     },
     notion: {
       prompt: getPrompt("notion.md"),

--- a/agent-chat-cli.config.ts
+++ b/agent-chat-cli.config.ts
@@ -3,7 +3,7 @@ import { getPrompt } from "./src/utils/getPrompt"
 
 const config: AgentChatConfig = {
   stream: false,
-  permissionMode: "default",
+  permissionMode: "bypassPermissions",
   mcpServers: {
     github: {
       prompt: getPrompt("github.md"),

--- a/src/components/AgentChat.tsx
+++ b/src/components/AgentChat.tsx
@@ -4,12 +4,11 @@ import { ChatHeader } from "components/ChatHeader"
 import { Markdown } from "components/Markdown"
 import { Stats } from "components/Stats"
 import { ToolPermissionPrompt } from "components/ToolPermissionPrompt"
+import { ToolUses } from "components/ToolUses"
 import { UserInput } from "components/UserInput"
 import { useAgent } from "hooks/useAgent"
 import { useMcpClient } from "hooks/useMcpClient"
 import { AgentStore } from "store"
-import { formatToolInput } from "utils/formatToolInput"
-import { getToolInfo } from "utils/getToolInfo"
 
 export const AgentChat: React.FC = () => {
   const actions = AgentStore.useStoreActions((actions) => actions)
@@ -64,34 +63,7 @@ export const AgentChat: React.FC = () => {
                   }
 
                   case entry.type === "tool_use": {
-                    const { serverName, toolName } = getToolInfo(entry.name)
-
-                    return (
-                      <Box flexDirection="column" marginBottom={1}>
-                        <Box>
-                          {serverName ? (
-                            <>
-                              <Text bold color="yellow">
-                                [{serverName}]
-                              </Text>
-                              <Text color="yellow">: {toolName}</Text>
-                            </>
-                          ) : (
-                            <Text color="yellow">[tool] {entry.name}</Text>
-                          )}
-                        </Box>
-
-                        <Box marginLeft={2} flexDirection="column">
-                          {formatToolInput(entry.input)
-                            .split("\n")
-                            .map((line, lineIdx) => (
-                              <Text key={lineIdx} dimColor>
-                                {line}
-                              </Text>
-                            ))}
-                        </Box>
-                      </Box>
-                    )
+                    return <ToolUses entry={entry} />
                   }
                 }
               })()}

--- a/src/store.ts
+++ b/src/store.ts
@@ -28,10 +28,17 @@ export interface ToolUse {
   input: Record<string, unknown>
 }
 
-export type ChatHistoryEntry = Message | ToolUse
+export interface ToolDenied {
+  type: "tool_denied"
+  name: string
+  reason: string
+}
+
+export type ChatHistoryEntry = Message | ToolUse | ToolDenied
 
 type McpServerConfigWithPrompt = McpServerConfig & {
   prompt?: string
+  denyTools?: string[]
 }
 
 export interface AgentChatConfig {

--- a/src/utils/getToolInfo.ts
+++ b/src/utils/getToolInfo.ts
@@ -1,7 +1,46 @@
-export const getToolInfo = (toolName: string) => {
-  const parts = toolName.split("__")
-  const serverName = parts.length >= 3 && parts[0] === "mcp" ? parts[1] : null
-  const name = serverName ? parts.slice(2).join("__") : toolName
+import type { AgentChatConfig } from "store"
 
-  return { serverName, toolName: name }
+export const getToolInfo = (tool: string) => {
+  const parts = tool.split("__")
+  const serverName = parts.length >= 3 && parts[0] === "mcp" ? parts[1] : null
+  const toolName = serverName ? parts.slice(2).join("__") : tool
+
+  return {
+    serverName,
+    toolName,
+  }
+}
+
+/**
+ * Get disallowedTools list from MCP server denyTools config.
+ * Converts tool names like "search_repositories" to "mcp__github__search_repositories"
+ */
+export const getDisallowedTools = (config: AgentChatConfig): string[] => {
+  const disallowed = Object.entries(config.mcpServers).flatMap(
+    ([serverName, serverConfig]) => {
+      if (!serverConfig.denyTools) {
+        return []
+      }
+
+      return serverConfig.denyTools.map(
+        (toolName) => `mcp__${serverName}__${toolName}`
+      )
+    }
+  )
+
+  return disallowed
+}
+
+export interface IsToolDisallowedProps {
+  toolName: string
+  config: AgentChatConfig
+}
+
+export const isToolDisallowed = ({
+  toolName,
+  config,
+}: IsToolDisallowedProps): boolean => {
+  const disallowed = getDisallowedTools(config)
+  const isDisallowed = disallowed.includes(toolName)
+  return isDisallowed
 }

--- a/src/utils/runAgentLoop.ts
+++ b/src/utils/runAgentLoop.ts
@@ -2,6 +2,7 @@ import { query, type SDKUserMessage } from "@anthropic-ai/claude-agent-sdk"
 import type { AgentChatConfig } from "store"
 import { buildSystemPrompt } from "utils/getPrompt"
 import { createCanUseTool } from "utils/canUseTool"
+import { getDisallowedTools } from "utils/getToolInfo"
 import type { MessageQueue } from "utils/MessageQueue"
 
 export const messageTypes = {
@@ -37,6 +38,8 @@ export const runAgentLoop = ({
     setIsProcessing,
   })
 
+  const disallowedTools = getDisallowedTools(config)
+
   const response = query({
     prompt: startConversation(messageQueue, sessionId),
     options: {
@@ -47,6 +50,7 @@ export const runAgentLoop = ({
       abortController,
       canUseTool,
       systemPrompt,
+      disallowedTools,
     },
   })
 


### PR DESCRIPTION
Adds ability to define tools that should be denied invocation. Under the hood it things are passed to the `disallowedTools` claude agent sdk query arg (safety ensured), but formatted correctly. For example: `search_repositories` -> `mcp__github__search_repositories`. 

<img width="429" height="283" alt="Screenshot 2025-10-05 at 9 25 34 PM" src="https://github.com/user-attachments/assets/0bdd11c6-ad0f-4738-8abb-b9cff90a3f60" />
